### PR TITLE
Restructure bot for slash commands

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,4 +3,5 @@ USER_LOGIN=[uplay_email:uplay_password]
 DEPLOY_MODE=dev
 REDIS_URL=redis://[user]:[pass]@[domain]:[port]/
 ADMIN_TAG=user#0001
+ADMIN_SERVER_ID=[server_id]
 ADMIN_CHANNEL_ID=[channel_id]

--- a/.env.template
+++ b/.env.template
@@ -3,3 +3,4 @@ USER_LOGIN=[uplay_email:uplay_password]
 DEPLOY_MODE=dev
 REDIS_URL=redis://[user]:[pass]@[domain]:[port]/
 ADMIN_TAG=user#0001
+ADMIN_CHANNEL_ID=[channel_id]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To run it, just run an `npm i` and an `npm start`. Make sure you've added a `.en
 
 - `DISCORD_TOKEN` is the Discord bot's auth token (see any tutorial for more info).
 - `USER_LOGIN` is your UPlay/Ubisoft Connect credentials - I suggest not using your main account. It doesn't have to own the game, so you can just create a new one for this bot.
-- `DEPLOY_MODE` should only be `prod` if it's supposed to be live. Everything else is interpreted as a development mode (which means that all commands will be prefixed with `dev` - e.g. `!devtotd today`).
+- `DEPLOY_MODE` should only be `prod` if it's supposed to be live. Everything else is interpreted as a development mode (which means that all commands will be registered only in the admin server, and the bot won't reload all the data on startup).
 - `REDIS_URL` is a Redis database - it's required for the scheduled messages and caching. If you're using an insecure instance for local development, you can omit the auth part.
 - `ADMIN_TAG` is the Discord tag of the bot admin - used for administration commands that only they should be allowed to run.
 - `ADMIN_SERVER_ID` and `ADMIN_CHANNEL_ID` are Discord IDs of the admin server and channel - used for all admin commands.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TOTD Discord Bot
 
-This is a Discord bot for displaying the daily [Trackmania](https://www.trackmania.com/) Track of the Day (and maybe more in the future).
+This is a Discord bot for displaying the daily [Trackmania](https://www.trackmania.com/) Track of the Day (and a few other things).
 
 **Disclaimer:** This bot uses undocumented APIs (and libraries based on them), so it may break at any time - potentially indefinitely if Nadeo/Ubisoft decide to close off those APIs.
 
@@ -8,32 +8,33 @@ This is a Discord bot for displaying the daily [Trackmania](https://www.trackman
 
 ## What can this bot do? 🤖
 
-**Public invite link:** [Click here!](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=bot)
+**Public invite link:** [Click here!](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=applications.commands%20bot)
 
-Use at your own risk - the bot is in development and may break from time to time.
+**Note:** The bot is now using slash commands instead of the `!totd` prefix - if you've used the bot before, you'll need to simply use the invite link above to update its permissions.
 
-- `!totd today` - Prints the current TOTD information to the current channel.
-- `!totd leaderboard` - Prints the current TOTD top 10 and the time needed for top 100 to the current channel.
-- `!totd verdict` - Prints yesterday's global ratings and a short verdict based on them.
-- `!totd ratings` - Prints today's global ratings.
-- `!totd rankings [time frame]` - Prints the TOTD rankings for the given time frame. Supported time frames are `this month`, `last month`, `this year`, `last year`, and `all time`.
-- `!totd bingo` - Prints this week's bingo board.
-- `!totd last bingo` - Prints last week's bingo board.
-- `!totd vote [1-25]` - Starts a vote on that bingo field. All ongoing votes are resolved when the next TOTD is released.
-- `!totd enable` - Stores the current channel to the list the daily scheduled TOTD post gets sent to. One channel per server. Admin only.
-- `!totd disable` - Removes the current channel from the list the scheduled TOTD post gets sent to. Admin only.
-- `!totd set role [@role] [region]` - Adds the role to the list of roles it pings 10 minutes before COTD. Daily TOTD posts have to be set up already. Supported regions for pings are `Europe`, `America`, and `Asia` - one for each official COTD. Admin only.
-- `!totd remove role [region]` - Removes the currently set role from the pings. Admin only.
-- `!totd help` - Displays some info about the bot.
+- `/today` - Prints the current TOTD information to the current channel.
+- `/leaderboard` - Prints the current TOTD top 10 and the time needed for top 100 to the current channel.
+- `/verdict` - Prints yesterday's global ratings and a short verdict based on them.
+- `/ratings` - Prints today's global ratings.
+- `/rankings [time frame]` - Prints the TOTD rankings for the given time frame. Supported time frames are `this month`, `last month`, `this year`, `last year`, and `all time`.
+- `/bingo` - Prints this week's bingo board.
+- `/lastbingo` - Prints last week's bingo board.
+- `/votebingo [1-25]` - Starts a vote on that bingo field. All ongoing votes are resolved when the next TOTD is released.
+- `/enable` - Stores the current channel to the list the daily scheduled TOTD post gets sent to. One channel per server. Admin only.
+- `/disable` - Removes the current channel from the list the scheduled TOTD post gets sent to. Admin only.
+- `/enablepings [@role] [region]` - Adds the role to the list of roles it pings 10 minutes before COTD. Daily TOTD posts have to be set up already. Supported regions for pings are `Europe`, `America`, and `Asia` - one for each official COTD. Admin only.
+- `/disablepings [region]` - Removes the currently set role from the pings. Admin only.
+- `/help` - Displays some info about the bot.
+- `/invite` - Displays a link to invite the bot to your server.
 
 Debug (and bot admin) only:
 
-- `!totd refresh today` - Refreshes the internally cached TOTD information.
-- `!totd refresh leaderboard` - Refreshes the internally cached leaderboard information.
-- `!totd refresh ratings` - Prints the current global ratings and a short verdict based on them (admin-only since it's not resolved yet).
-- `!totd refresh bingo` - Regenerates the current bingo board.
-- `!totd refresh count` - Resolves the ongoing bingo field votes.
-- `!totd servers` - Prints the current number of servers the bot is in. Also logs the server details.
+- `/refreshtotd` - Refreshes the internally cached TOTD information.
+- `/refreshleaderboard` - Refreshes the internally cached leaderboard information.
+- `/refreshratings` - Prints the current global ratings and a short verdict based on them (admin-only since it's not resolved yet).
+- `/refreshbingo` - Regenerates the current bingo board.
+- `/refreshbingocount` - Resolves the ongoing bingo field votes.
+- `/servers` - Prints the current number of servers the bot is in. Also logs the server details.
 
 ## Screenshots 📷
 
@@ -52,7 +53,8 @@ To run it, just run an `npm i` and an `npm start`. Make sure you've added a `.en
 - `USER_LOGIN` is your UPlay/Ubisoft Connect credentials - I suggest not using your main account. It doesn't have to own the game, so you can just create a new one for this bot.
 - `DEPLOY_MODE` should only be `prod` if it's supposed to be live. Everything else is interpreted as a development mode (which means that all commands will be prefixed with `dev` - e.g. `!devtotd today`).
 - `REDIS_URL` is a Redis database - it's required for the scheduled messages and caching. If you're using an insecure instance for local development, you can omit the auth part.
-- `ADMIN_TAG` is the Discord tag of the bot admin - mainly used for undocumented debug commands that only they should be allowed to run.
+- `ADMIN_TAG` is the Discord tag of the bot admin - used for administration commands that only they should be allowed to run.
+- `ADMIN_SERVER_ID` and `ADMIN_CHANNEL_ID` are Discord IDs of the admin server and channel - used for all admin commands.
 
 Every commit on `main` triggers an update to the live version of the bot running on a Heroku dyno.
 

--- a/main.js
+++ b/main.js
@@ -20,6 +20,8 @@ const constants = require(`./src/constants`);
 
 const discordToken = process.env.DISCORD_TOKEN;
 const deployMode = process.env.DEPLOY_MODE;
+const adminServerID = process.env.ADMIN_SERVER_ID;
+const adminChannelID = process.env.ADMIN_CHANNEL_ID;
 
 // COTD pings for 7pm (Europe)
 new cron(
@@ -79,6 +81,32 @@ new cron(
 client.on(`ready`, async () => {
   console.log(`Ready as ${client.user.tag}!`);
 
+  const globalCommandConfigs = commands.globalCommands.map((commandConfig) => commandConfig.slashCommand);
+  const adminCommandConfigs = commands.adminCommands.map((commandConfig) => commandConfig.slashCommand);
+
+  const adminGuild = await client.guilds.fetch(adminServerID);
+  let globalCommandManager;
+  if (deployMode !== `prod`) {
+    // use admin guild for global commands in dev mode
+    globalCommandManager = adminGuild.commands;
+  } else {
+    globalCommandManager = await client.application.commands;
+  }
+  const adminCommandManager = adminGuild.commands;
+
+  for (const commandConfig of globalCommandConfigs) {
+    if (commandConfig) {
+      await globalCommandManager.create(commandConfig);
+      console.log(`Registered global command: ${commandConfig.name}`);
+    }
+  }
+  for (const commandConfig of adminCommandConfigs) {
+    if (commandConfig) {
+      await adminCommandManager.create(commandConfig);
+      console.log(`Registered admin command: ${commandConfig.name}`);
+    }
+  }
+
   // in production, refresh TOTD to make sure there is a thumbnail in the images for cached messages
   if (deployMode === `prod`) {
     await discordAPI.getTOTDMessage(true);
@@ -119,58 +147,58 @@ client.on(`ready`, async () => {
   }
 });
 
+client.on(`interactionCreate`, async (interaction) => {
+  if (interaction.isCommand()) {
+    if (!interaction.guildId) {
+      // bot doesn't support DMs for now, reply with an explanation
+      return await interaction.reply(`Sorry, I don't support DMs (yet). Please use my commands in a server that we share.`);
+    }
+
+    console.log(`Received command: ${interaction.commandName} (#${interaction.channel.name} in ${interaction.guild?.name})`);
+    const joinedCommands = commands.globalCommands.concat(commands.adminCommands);
+    const matchedCommand = joinedCommands.find((commandConfig) => commandConfig?.slashCommand?.name === interaction.commandName);
+    if (matchedCommand) {
+      try {
+        await matchedCommand.action(interaction, client);
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      console.error(`No matching command found`);
+    }
+  }
+});
+
 client.on(`messageCreate`, async (msg) => {
   if (msg.guild && msg.content.startsWith(utils.addDevPrefix(`!totd`))) {
     console.log(`Received message: ${msg.content} (#${msg.channel.name} in ${msg.guild.name})`);
-
-    const matchedCommand = commands.find((command) => {
-      let aliases = [];
-      if (Array.isArray(command.command)) {
-        aliases = command.command;
+    try {
+      const title = `I've switched from the \`!totd\` prefix to slash commands!`;
+      const instructions = `Just type \`/help\` to see the new commands! Make sure you select the correct command, you can always recognize me by my ${utils.getEmojiMapping(`Author`)} avatar.`;
+      const message = `If you can't see any of my commands when you type \`/\` (e.g. \`/today\` or \`/help\`), tell an admin to invite me again with the following link.\nThat will update my permissions and allow you to use my commands.`;
+      const devDisclaimer = `Run into any problems with that? Feel free to open an issue [here](https://github.com/davidbmaier/totd-bot/issues).`;
+      const formattedMessage = format.formatInviteMessage(title, `${instructions}\n\n${message}\n${devDisclaimer}`);
+      utils.sendMessage(
+        msg.channel,
+        formattedMessage,
+        msg
+      );
+    } catch (error) {
+      if (error.message === `Missing Permissions`) {
+        console.error(`Unable to send error message to channel #${msg.channel.name} in ${msg.guild.name}, no permissions`);
       } else {
-        aliases = [command.command];
-      }
-
-      const matchedAlias = aliases.find((alias) => msg.content.toLowerCase().startsWith(alias.toLowerCase()));
-      return !!matchedAlias;
-    });
-
-    if (matchedCommand) {
-      try {
-        await matchedCommand.action(msg, client);
-      } catch (error) {
-        if (error.message === `Missing Permissions`) {
-          console.error(`Unable to send error message to channel #${msg.channel.name} in ${msg.guild.name}, no permissions`);
-        } else {
-          console.error(`Unexpected error while sending error message to channel #${msg.channel.name} in ${msg.guild.name}`);
-          console.error(error.message);
-        }
-      }
-    } else {
-      try {
-        await msg.channel.send(
-          `I don't know what to do, you might want to check \`${utils.addDevPrefix(`!totd help`)}\` to see what I can understand.`
-        );
-      } catch (error) {
-        if (error.message === `Missing Permissions`) {
-          console.error(`Unable to send error message to channel #${msg.channel.name} in ${msg.guild.name}, no permissions`);
-        } else {
-          console.error(`Unexpected error while sending error message to channel #${msg.channel.name} in ${msg.guild.name}`);
-          console.error(error.message);
-        }
+        console.error(`Unexpected error while sending error message to channel #${msg.channel.name} in ${msg.guild.name}`);
+        console.error(error.message);
       }
     }
   } else if (msg.mentions.has(client.user.id, {ignoreEveryone: true})) {
     const redisClient = await redisAPI.login();
-    const adminConfig = await redisAPI.getAdminServer(redisClient);
     redisAPI.logout(redisClient);
 
-    if (adminConfig?.channelID) {
-      console.log(`Proxying mention to admin server...`);
-      const adminChannel = await client.channels.fetch(adminConfig.channelID);
-      const proxyMessage = format.formatProxyMessage(msg);
-      adminChannel.send(proxyMessage);
-    }
+    console.log(`Proxying mention to admin server...`);
+    const adminChannel = await client.channels.fetch(adminChannelID);
+    const proxyMessage = format.formatProxyMessage(msg);
+    utils.sendMessage(adminChannel, proxyMessage);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "totd-bot",
   "description": "Discord bot for displaying the daily Trackmania Track of the Day",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "main": "main.js",
   "repository": {
     "type": "git",

--- a/src/commands.js
+++ b/src/commands.js
@@ -560,8 +560,87 @@ const serverInfo = {
         // fetch and log detailed infos asynchronously
         servers.forEach(async (server) => {
           const owner = await client.users.fetch(server.ownerId); // don't use fetchOwner since we need the owner user, not the guild member
-          console.log(`Server: ${server.name} - Owner: ${JSON.stringify(owner.tag)} - ID: ${server.id}`);
+          console.log(`Server: ${server.name} - Owner: ${owner.tag} - ID: ${server.id}`);
         });
+      } catch (error) {
+        discordAPI.sendErrorMessage(msg.channel);
+        console.error(error);
+      }
+    }
+  }
+};
+
+const notifyServersWithWrongPermissions = {
+  slashCommand: {
+    name: `notifywrongpermissions`,
+    description: `Notify all server owners where the bot is lacking slash command permmissions.`,
+    type: `CHAT_INPUT`,
+    options: [
+      {
+        type: `BOOLEAN`,
+        name: `senddms`,
+        description: `Whether DMs should be sent to the server owners.`,
+        required: true,
+      }
+    ]
+  },
+  action: async (msg, client) => {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
+      try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
+        const serversWithWrongPermissions = [];
+        const servers = client.guilds.cache;
+        for (const server of servers.values()) {
+          try {
+            // attempt to create a test command - there's apparently no other way to check whether the bot has application commands permissions
+            const testCommand = await server.commands.create({
+              name: `totdtest`,
+              description: `Test command for the TOTD bot.`,
+            });
+            await testCommand.delete();
+          } catch (error) {
+            if (error.message === `Missing Access` || error.message === `Missing Permissions`) {
+              serversWithWrongPermissions.push(server);
+            } else {
+              console.error(`Something else went wrong for server ${server.name}.`);
+              console.error(error);
+            }
+          }
+        }
+
+        if (msg.options.get(`senddms`).value) {
+          serversWithWrongPermissions.forEach(async (server) => {
+            const owner = await client.users.fetch(server.ownerId);
+            console.log(`Server ${server.name} doesn't have slash command permissions, sending DM to ${owner.tag}.`);
+            try {
+              await owner.send({
+                embeds: [
+                  {
+                    title: `A quick update about the TOTD Bot`,
+                    description: `Hey ${owner.username}, thanks for using the TOTD Bot!\n`
+                      + `I've recently switched from \`!totd\` commands to slash commands so I can get verified by Discord.\n`
+                      + `However, it looks like **I don't have the required permissions** on your server "**${server.name}**" to register my commands.\n`
+                      + `Until that's fixed the scheduled TOTD posts will still work, but you won't be able to tell me to do anything.\n\n`
+                      + `**Please invite me again with the following link** (all the permissions are the same as before, the only change is the extra \`applications.commands\` scope).\n`
+                      + `If you're running into any issues with that, or you still can't see my commands afterwards, please talk to tooInfinite#5113 or [open an issue on the Github repo](https://github.com/davidbmaier/totd-bot/issues).\n`
+                      + `**Click [here](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=applications.commands%20bot) for the invite!**`
+                  }
+                ]
+              });
+            } catch (dmError) {
+              console.error(`Something went wrong while sending a DM to ${owner.tag} for server ${server.name}.`);
+              console.error(dmError);
+            }
+          });
+
+          response.edit(`I've DM'd all the server owners that haven't updated their permissions for me yet!`);
+        } else {
+          response.edit(`I've found ${serversWithWrongPermissions.length} servers that don't have the required permissions for me to register my commands.`);
+          serversWithWrongPermissions.forEach(async (server) => {
+            const owner = await client.users.fetch(server.ownerId);
+            console.log(`Server with missing slash command permissions: ${server.name} - Owner: ${owner.tag} - ID: ${server.id}`);
+          });
+        }
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -612,6 +691,7 @@ module.exports = {
     refreshBingo,
     refreshBingoCount,
     debug,
-    serverInfo
+    serverInfo,
+    notifyServersWithWrongPermissions
   ]
 };

--- a/src/commands.js
+++ b/src/commands.js
@@ -9,10 +9,14 @@ const constants = require(`./constants`);
 const adminTag = process.env.ADMIN_TAG;
 
 const today = {
-  command: utils.addDevPrefix(`!totd today`),
+  slashCommand: {
+    name: `today`,
+    description: `Display the current Track of the Day`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg, client) => {
     try {
-      await discordAPI.sendTOTDMessage(client, msg.channel, await discordAPI.getTOTDMessage());
+      await discordAPI.sendTOTDMessage(client, msg.channel, await discordAPI.getTOTDMessage(), msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -21,10 +25,14 @@ const today = {
 };
 
 const leaderboard = {
-  command: utils.addDevPrefix(`!totd leaderboard`),
+  slashCommand: {
+    name: `leaderboard`,
+    description: `Display the current TOTD leaderboard and trophy thresholds.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg, client) => {
     try {
-      await discordAPI.sendTOTDLeaderboard(client, msg.channel);
+      await discordAPI.sendTOTDLeaderboard(client, msg.channel, msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -33,10 +41,32 @@ const leaderboard = {
 };
 
 const verdict = {
-  command: [utils.addDevPrefix(`!totd verdict`), utils.addDevPrefix(`!totd yesterday`)],
+  slashCommand: {
+    name: `verdict`,
+    description: `Display yesterday's TOTD ratings.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg, client) => {
     try {
-      await discordAPI.sendTOTDRatings(client, msg.channel, true);
+      await discordAPI.sendTOTDRatings(client, msg.channel, true, msg);
+    } catch (error) {
+      discordAPI.sendErrorMessage(msg.channel);
+      console.log(error);
+    }
+  }
+};
+
+
+// command to see the current ratings
+const ratings = {
+  slashCommand: {
+    name: `ratings`,
+    description: `Display the current TOTD ratings.`,
+    type: `CHAT_INPUT`,
+  },
+  action: async (msg, client) => {
+    try {
+      await discordAPI.sendTOTDRatings(client, msg.channel, false, msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -45,56 +75,96 @@ const verdict = {
 };
 
 const enable = {
-  command: utils.addDevPrefix(`!totd enable`),
+  slashCommand: {
+    name: `enable`,
+    description: `Enable daily posts in this channel when the new TOTD is released.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.member.permissions.has(`ADMINISTRATOR`) || msg.author.tag === adminTag) {
+    if (msg.member.permissions.has(`ADMINISTRATOR`) || utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
         const redisClient = await redisAPI.login();
         await redisAPI.addConfig(redisClient, msg.guild.id, msg.channel.id);
         redisAPI.logout(redisClient);
-        msg.channel.send(`You got it, I'll post the TOTD every day just after it comes out.`);
+        utils.sendMessage(msg.channel, `You got it, I'll post the TOTD every day just after it comes out.`, msg);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.log(error);
       }
     } else {
-      msg.channel.send(`You don't have \`ADMINISTRATOR\` permission, sorry.`);
+      utils.sendMessage(msg.channel, `You don't have \`ADMINISTRATOR\` permission, sorry.`, msg);
     }
   }
 };
 
 const disable = {
-  command: utils.addDevPrefix(`!totd disable`),
+  slashCommand: {
+    name: `disable`,
+    description: `Disable daily TOTD posts again.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.member.permissions.has(`ADMINISTRATOR`) || msg.author.tag === adminTag) {
+    if (msg.member.permissions.has(`ADMINISTRATOR`) || utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
         const redisClient = await redisAPI.login();
         await redisAPI.removeConfig(redisClient, msg.guild.id);
         redisAPI.logout(redisClient);
-        msg.channel.send(`Alright, I'll stop posting from now on.`);
+        utils.sendMessage(msg.channel, `Alright, I'll stop posting from now on.`, msg);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.log(error);
       }
     } else {
-      msg.channel.send(`You don't have \`ADMINISTRATOR\` permissions, sorry.`);
+      utils.sendMessage(msg.channel, `You don't have \`ADMINISTRATOR\` permissions, sorry.`, msg);
     }
   }
 };
 
 const setRole = {
-  command: utils.addDevPrefix(`!totd set role`),
+  slashCommand: {
+    name: `enablepings`,
+    description: `Enable reminder pings for a role ten minutes before COTD.`,
+    type: `CHAT_INPUT`,
+    options: [
+      {
+        type: `STRING`,
+        name: `role`,
+        description: `The role that should be pinged. Format: @role`,
+        required: true,
+      },
+      {
+        type: `STRING`,
+        name: `region`,
+        description: `The region that the role should be pinged for.`,
+        required: true,
+        choices: [
+          {
+            name: constants.cupRegions.europe,
+            value: constants.cupRegions.europe
+          },
+          {
+            name: constants.cupRegions.america,
+            value: constants.cupRegions.america
+          },
+          {
+            name: constants.cupRegions.asia,
+            value: constants.cupRegions.asia
+          },
+        ]
+      }
+    ]
+  },
   action: async (msg) => {
-    if (msg.member.permissions.has(`ADMINISTRATOR`) || msg.author.tag === adminTag) {
+    if (msg.member.permissions.has(`ADMINISTRATOR`) || utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
         const redisClient = await redisAPI.login();
         const configs = await redisAPI.getAllConfigs(redisClient);
         // check if this server already has daily posts set up
         const matchingConfig = configs.find((config) => config.serverID === msg.guild.id);
         if (matchingConfig) {
-          const role = msg.content.split(` `)[3];
+          const role = msg.options.get(`role`).value;
           if (role.startsWith(`<@&`)) {
-            const region = msg.content.split(` `)[4];
+            const region = msg.options.get(`region`).value;
             // valid regions: "Europe" (7pm), "America" (3am), "Asia" (11am)
             if (region) {
               const regions = constants.cupRegions;
@@ -104,22 +174,22 @@ const setRole = {
                 || region === regions.asia
               ) {
                 await redisAPI.addRole(redisClient, msg.guild.id, role, region);
-                msg.channel.send(`Okay, from now on I'll ping that role ten minutes before the ${region} COTD starts.`);
+                utils.sendMessage(msg.channel, `Okay, from now on I'll ping that role ten minutes before the ${region} COTD starts.`, msg);
               } else {
                 const message1 = `Sorry, I only know three regions: \`${regions.europe}\`, \`${regions.america}\`, and \`${regions.asia}\` - `;
-                const message2 = `tell me to set up a role for a region by using \`${utils.addDevPrefix(`!totd set role @[role] [region]`)}\`.\n`;
+                const message2 = `tell me to set up a role for a region by using \`${utils.addDevPrefix(`/enablepings @[role] [region]`)}\`.\n`;
                 const message3 = `If you just want to set up pings for the main Europe event, you can leave out the region.`;
-                msg.channel.send(`${message1}${message2}${message3}`);
+                utils.sendMessage(msg.channel, `${message1}${message2}${message3}`, msg);
               }
             } else {
               await redisAPI.addRole(redisClient, msg.guild.id, role);
-              msg.channel.send(`Okay, from now on I'll ping that role ten minutes before the main COTD starts.`);
+              utils.sendMessage(msg.channel, `Okay, from now on I'll ping that role ten minutes before the main COTD starts.`, msg);
             }
           } else {
-            msg.channel.send(`Sorry, I only understand roles that look like \`@role\` - and I obviously don't accept user IDs either.`);
+            utils.sendMessage(msg.channel, `Sorry, I only understand roles that look like \`@role\` - and I obviously don't accept user IDs either.`, msg);
           }
         } else {
-          msg.channel.send(`Sorry, you'll need to enable the daily posts first.`);
+          utils.sendMessage(msg.channel, `Sorry, you'll need to enable the daily posts first.`, msg);
         }
         redisAPI.logout(redisClient);
       } catch (error) {
@@ -127,18 +197,44 @@ const setRole = {
         console.log(error);
       }
     } else {
-      msg.channel.send(`You don't have \`ADMINISTRATOR\` permissions, sorry.`);
+      utils.sendMessage(msg.channel, `You don't have \`ADMINISTRATOR\` permissions, sorry.`, msg);
     }
   }
 };
 
 const removeRole = {
-  command: utils.addDevPrefix(`!totd remove role`),
+  slashCommand: {
+    name: `disablepings`,
+    description: `Disable TOTD reminder pings for a role.`,
+    type: `CHAT_INPUT`,
+    options: [
+      {
+        type: `STRING`,
+        name: `region`,
+        description: `The region that the role should be pinged for.`,
+        required: true,
+        choices: [
+          {
+            name: constants.cupRegions.europe,
+            value: constants.cupRegions.europe
+          },
+          {
+            name: constants.cupRegions.america,
+            value: constants.cupRegions.america
+          },
+          {
+            name: constants.cupRegions.asia,
+            value: constants.cupRegions.asia
+          },
+        ]
+      }
+    ]
+  },
   action: async (msg) => {
-    if (msg.member.permissions.has(`ADMINISTRATOR`) || msg.author.tag === adminTag) {
+    if (msg.member.permissions.has(`ADMINISTRATOR`) || utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
         const redisClient = await redisAPI.login();
-        const region = msg.content.split(` `)[3];
+        const region = msg.options.get(`region`).value;
         if (region) {
           const regions = constants.cupRegions;
           if (
@@ -147,15 +243,15 @@ const removeRole = {
             || region === regions.asia
           ) {
             await redisAPI.removeRole(redisClient, msg.guild.id, region);
-            msg.channel.send(`Okay, I'll stop the pings for the ${region} COTD.`);
+            utils.sendMessage(msg.channel, `Okay, I'll stop the pings for the ${region} COTD.`, msg);
           } else {
             const message1 = `Sorry, I only know three regions: \`${regions.europe}\`, \`${regions.america}\`, and \`${regions.asia}\`.\n`;
-            const message2 = `Tell me to remove a role for a region by using \`${utils.addDevPrefix(`!totd remove role [region]`)}\`.`;
-            msg.channel.send(`${message1}${message2}`);
+            const message2 = `Tell me to remove a role for a region by using \`${utils.addDevPrefix(`/disablepings [region]`)}\`.`;
+            utils.sendMessage(msg.channel, `${message1}${message2}`, msg);
           }
         } else {
           await redisAPI.removeRole(redisClient, msg.guild.id);
-          msg.channel.send(`Okay, I'll stop the pings for the main COTD.`);
+          utils.sendMessage(msg.channel, `Okay, I'll stop the pings for the main COTD.`, msg);
         }
         redisAPI.logout(redisClient);
       } catch (error) {
@@ -163,16 +259,20 @@ const removeRole = {
         console.log(error);
       }
     } else {
-      msg.channel.send(`You don't have \`ADMINISTRATOR\` permissions, sorry.`);
+      utils.sendMessage(msg.channel, `You don't have \`ADMINISTRATOR\` permissions, sorry.`, msg);
     }
   }
 };
 
 const bingo = {
-  command: utils.addDevPrefix(`!totd bingo`),
+  slashCommand: {
+    name: `bingo`,
+    description: `Display this week's bingo board.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
     try {
-      await discordAPI.sendBingoBoard(msg.channel);
+      await discordAPI.sendBingoBoard(msg.channel, false, msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -181,10 +281,14 @@ const bingo = {
 };
 
 const lastBingo = {
-  command: utils.addDevPrefix(`!totd last bingo`),
+  slashCommand: {
+    name: `lastbingo`,
+    description: `Display last week's bingo board.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
     try {
-      await discordAPI.sendBingoBoard(msg.channel, true);
+      await discordAPI.sendBingoBoard(msg.channel, true, msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -192,15 +296,36 @@ const lastBingo = {
   }
 };
 
+const bingoOptions = [];
+for (let i = 0; i < 25; i++) {
+  bingoOptions.push({
+    name: `Field ${i + 1}`,
+    value: `${i + 1}`
+  });
+}
+
 const bingoVote = {
-  command: utils.addDevPrefix(`!totd vote`),
+  slashCommand: {
+    name: `votebingo`,
+    description: `Start a vote for a bingo field.`,
+    type: `CHAT_INPUT`,
+    options: [
+      {
+        type: `STRING`,
+        name: `field`,
+        description: `The bingo field you want to start a vote for.`,
+        required: true,
+        choices: bingoOptions
+      }
+    ]
+  },
   action: async (msg) => {
     try {
-      const bingoID = msg.content.split(` `)[2];
+      const bingoID = msg.options.get(`field`).value;
       if (!bingoID || Number.isNaN(parseInt(bingoID))) {
-        msg.channel.send(`I didn't catch that - to vote on a bingo field, use \`!totd vote [1-25]\`.`);
+        utils.sendMessage(msg.channel, `I didn't catch that - to vote on a bingo field, use \`/bingovote [1-25]\`.`, msg);
       } else {
-        await discordAPI.sendBingoVote(msg.channel, parseInt(bingoID));
+        await discordAPI.sendBingoVote(msg.channel, parseInt(bingoID), msg);
       }
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
@@ -209,55 +334,15 @@ const bingoVote = {
   }
 };
 
-const help = {
-  command: utils.addDevPrefix(`!totd help`),
-  action: async (msg) => {
-    let message = `\`${utils.addDevPrefix(`!totd today`)}\`  -  Display the current TOTD information.\n \
-      \`${utils.addDevPrefix(`!totd leaderboard`)}\`  -  Display the current top 10 (and the time for top 100).\n \
-      \`${utils.addDevPrefix(`!totd verdict`)}\`  -  Display yesterday's TOTD ratings.\n \
-      \`${utils.addDevPrefix(`!totd ratings`)}\`  -  Display today's TOTD ratings.\n \
-      \`${utils.addDevPrefix(`!totd rankings [time frame]`)}\`  -  Display TOTD rankings based on bot ratings.\n \
-      (Time frames: \`this month\`, \`last month\`, \`this year\`, \`last year\` or \`all time\`)\n \
-      \`${utils.addDevPrefix(`!totd bingo`)}\`  -  Display this week's bingo board.\n \
-      \`${utils.addDevPrefix(`!totd last bingo`)}\`  -  Display last week's bingo board.\n \
-      \`${utils.addDevPrefix(`!totd vote [1-25]`)}\`  -  Start a vote to cross off that bingo field.`;
-
-    let adminMessage;
-    if (msg.member.permissions.has(`ADMINISTRATOR`) || msg.author.tag === adminTag) {
-      adminMessage = `\n\`${utils.addDevPrefix(`!totd enable`)}\`  -  Enable daily TOTD posts in this channel.\n \
-      \`${utils.addDevPrefix(`!totd disable`)}\`  -  Disable the daily posts again.\n \
-      \`${utils.addDevPrefix(`!totd set role [@role] [region]`)}\`  -  Enable pings ten minutes before COTD.\n \
-      \`${utils.addDevPrefix(`!totd remove role [region]`)}\`  -  Disable daily pings again.\n\
-      (Supported regions: \`${constants.cupRegions.europe}\`, \`${constants.cupRegions.america}\`, and \`${constants.cupRegions.asia}\`)`;
-    }
-    try {
-      const formattedMessage = format.formatHelpMessage(message, adminMessage);
-      await msg.channel.send(formattedMessage);
-    } catch (error) {
-      discordAPI.sendErrorMessage(msg.channel);
-      console.log(error);
-    }
-  }
-};
-
 const invite = {
-  command: utils.addDevPrefix(`!totd invite`),
+  slashCommand: {
+    name: `invite`,
+    description: `Get an invite link for the TOTD Bot.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
     try {
-      await msg.channel.send(format.formatInviteMessage());
-    } catch (error) {
-      discordAPI.sendErrorMessage(msg.channel);
-      console.log(error);
-    }
-  }
-};
-
-// command to see the current ratings
-const ratings = {
-  command: [utils.addDevPrefix(`!totd ratings`), utils.addDevPrefix(`!totd rating`)],
-  action: async (msg, client) => {
-    try {
-      await discordAPI.sendTOTDRatings(client, msg.channel);
+      utils.sendMessage(msg.channel, format.formatInviteMessage(), msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -266,35 +351,86 @@ const ratings = {
 };
 
 const rankings = {
-  command: [utils.addDevPrefix(`!totd rankings`), utils.addDevPrefix(`!totd ranking`)],
+  slashCommand: {
+    name: `rankings`,
+    description: `Display TOTD rankings based on bot ratings.`,
+    type: `CHAT_INPUT`,
+    options: [
+      {
+        type: `STRING`,
+        name: `timeframe`,
+        description: `The time frame you want to see rankings for.`,
+        required: true,
+        choices: [
+          {
+            name: `this month`,
+            value: constants.ratingRankingType.monthly,
+          },
+          {
+            name: `last month`,
+            value: constants.ratingRankingType.lastMonthly
+          },
+          {
+            name: `this year`,
+            value: constants.ratingRankingType.yearly
+          },
+          {
+            name: `last year`,
+            value: constants.ratingRankingType.lastYearly
+          },
+          {
+            name: `all time`,
+            value: constants.ratingRankingType.allTime
+          },
+        ]
+      }
+    ]
+  },
   action: async (msg) => {
     try {
-      // use the length of the longer command (cause the extra character is just a space that doesn't get trimmed)
-      const timeframe = msg.content.substr(utils.addDevPrefix(`!totd rankings`).length).trim();
-      const validTimeframes = [
-        {label: `month`, value: constants.ratingRankingType.monthly},
-        {label: `this month`, value: constants.ratingRankingType.monthly},
-        {label: `last month`, value: constants.ratingRankingType.lastMonthly},
-        {label: `year`, value: constants.ratingRankingType.yearly},
-        {label: `this year`, value: constants.ratingRankingType.yearly},
-        {label: `last year`, value: constants.ratingRankingType.lastYearly},
-        {label: `all-time`, value: constants.ratingRankingType.allTime},
-        {label: `all time`, value: constants.ratingRankingType.allTime}
-      ];
-      let matchingTimeframe = validTimeframes[0]; // monthly is default
-
-      validTimeframes.forEach((validTimeframe) => {
-        if (timeframe.startsWith(validTimeframe.label.toLowerCase())) {
-          matchingTimeframe = validTimeframe;
-        }
-      });
+      const matchingTimeframe = msg.options.get(`timeframe`).value;
 
       const redisClient = await redisAPI.login();
-      const rankings = await redisAPI.getRatingRankings(redisClient, matchingTimeframe.value);
+      const rankings = await redisAPI.getRatingRankings(redisClient, matchingTimeframe);
       redisAPI.logout(redisClient);
 
       const rankingMessage = format.formatRankingMessage(rankings, matchingTimeframe);
-      await msg.channel.send(rankingMessage);
+      utils.sendMessage(msg.channel, rankingMessage, msg);
+    } catch (error) {
+      discordAPI.sendErrorMessage(msg.channel);
+      console.log(error);
+    }
+  }
+};
+
+const help = {
+  slashCommand: {
+    name: `help`,
+    description: `Get a list of all commands for the TOTD Bot.`,
+    type: `CHAT_INPUT`,
+  },
+  action: async (msg) => {
+    let message = `\`/today\`  -  Display the current TOTD information.\n \
+      \`/leaderboard\`  -  Display the current top 10 (and the time for top 100).\n \
+      \`/verdict\`  -  Display yesterday's TOTD ratings.\n \
+      \`/ratings\`  -  Display today's TOTD ratings.\n \
+      \`/rankings [time frame]\`  -  Display TOTD rankings based on bot ratings.\n \
+      (Time frames: \`this month\`, \`last month\`, \`this year\`, \`last year\` or \`all time\`)\n \
+      \`/bingo\`  -  Display this week's bingo board.\n \
+      \`/lastbingo\`  -  Display last week's bingo board.\n \
+      \`/bingovote [1-25]\`  -  Start a vote to cross off that bingo field.`;
+
+    let adminMessage;
+    if (msg.member.permissions.has(`ADMINISTRATOR`) || utils.checkMessageAuthorForTag(msg, adminTag)) {
+      adminMessage = `\n\`/enable\`  -  Enable daily TOTD posts in this channel.\n \
+      \`/disable\`  -  Disable the daily posts again.\n \
+      \`/enablepings [@role] [region]\`  -  Enable pings ten minutes before COTD.\n \
+      \`/disablepings [region]\`  -  Disable daily pings again.\n\
+      (Supported regions: \`${constants.cupRegions.europe}\`, \`${constants.cupRegions.america}\`, and \`${constants.cupRegions.asia}\`)`;
+    }
+    try {
+      const formattedMessage = format.formatHelpMessage(message, adminMessage);
+      utils.sendMessage(msg.channel, formattedMessage, msg);
     } catch (error) {
       discordAPI.sendErrorMessage(msg.channel);
       console.log(error);
@@ -303,12 +439,17 @@ const rankings = {
 };
 
 const refresh = {
-  command: utils.addDevPrefix(`!totd refresh today`),
+  slashCommand: {
+    name: `refreshtotd`,
+    description: `Manually refresh the current TOTD data.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
         await discordAPI.getTOTDMessage(true);
-        await msg.channel.send(`I've refreshed the current TOTD data!`);
+        response.edit(`I've refreshed the current TOTD data!`);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -318,12 +459,17 @@ const refresh = {
 };
 
 const refreshLeaderboard = {
-  command: utils.addDevPrefix(`!totd refresh leaderboard`),
+  slashCommand: {
+    name: `refreshleaderboard`,
+    description: `Manually refresh the current leaderboard data.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
         await discordAPI.getTOTDLeaderboardMessage(true);
-        await msg.channel.send(`I've refreshed the current leaderboard data!`);
+        response.edit(`I've refreshed the current leaderboard data!`);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -333,14 +479,19 @@ const refreshLeaderboard = {
 };
 
 const refreshRatings = {
-  command: utils.addDevPrefix(`!totd refresh ratings`),
+  slashCommand: {
+    name: `refreshratings`,
+    description: `Manually refresh the current ratings data.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
         const redisClient = await redisAPI.login();
         await redisAPI.clearTOTDRatings(redisClient);
         redisAPI.logout(redisClient);
-        await msg.channel.send(`I've refreshed the current rating data!`);
+        response.edit(`I've refreshed the current rating data!`);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -350,12 +501,17 @@ const refreshRatings = {
 };
 
 const refreshBingo = {
-  command: utils.addDevPrefix(`!totd refresh bingo`),
+  slashCommand: {
+    name: `refreshbingo`,
+    description: `Manually refresh the current bingo board.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
         await discordAPI.getBingoMessage(true);
-        await msg.channel.send(`I've refreshed the current bingo board!`);
+        response.edit(`I've refreshed the current bingo board!`);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -364,47 +520,18 @@ const refreshBingo = {
   }
 };
 
-const bingoCount = {
-  command: utils.addDevPrefix(`!totd refresh count`),
+const refreshBingoCount = {
+  slashCommand: {
+    name: `refreshbingocount`,
+    description: `Manually refresh the current bingo vote count.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg, client) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
+        const response = await utils.sendMessage(msg.channel, `Working on it... ${utils.getEmojiMapping(`Loading`)}`, msg);
         await discordAPI.countBingoVotes(client);
-        await msg.channel.send(`I've counted and resolved the current bingo votes!`);
-      } catch (error) {
-        discordAPI.sendErrorMessage(msg.channel);
-        console.error(error);
-      }
-    }
-  }
-};
-
-const setAdminServer = {
-  command: utils.addDevPrefix(`!totd set admin`),
-  action: async (msg) => {
-    if (msg.author.tag === adminTag) {
-      try {
-        const redisClient = await redisAPI.login();
-        await redisAPI.setAdminServer(redisClient, msg.guild.id, msg.channel.id);
-        redisAPI.logout(redisClient);
-        await msg.channel.send(`Alright, this is now the admin server!`);
-      } catch (error) {
-        discordAPI.sendErrorMessage(msg.channel);
-        console.error(error);
-      }
-    }
-  }
-};
-
-const removeAdminServer = {
-  command: utils.addDevPrefix(`!totd remove admin`),
-  action: async (msg) => {
-    if (msg.author.tag === adminTag) {
-      try {
-        const redisClient = await redisAPI.login();
-        await redisAPI.setAdminServer(redisClient, null);
-        redisAPI.logout(redisClient);
-        await msg.channel.send(`I've removed the admin server configuration!`);
+        response.edit(`I've counted and resolved the current bingo votes!`);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -414,9 +541,13 @@ const removeAdminServer = {
 };
 
 const serverInfo = {
-  command: utils.addDevPrefix(`!totd servers`),
+  slashCommand: {
+    name: `servers`,
+    description: `Get information about the servers the TOTD bot is in.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg, client) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
         const servers = [];
         let memberCount = 0;
@@ -424,7 +555,7 @@ const serverInfo = {
           servers.push(guild);
           memberCount += guild.memberCount;
         });
-        await msg.channel.send(`I'm currently in ${servers.length} servers and counting - reaching an audience of ${memberCount}!`);
+        utils.sendMessage(msg.channel, `I'm currently in ${servers.length} servers and counting - reaching an audience of ${memberCount}!`, msg);
 
         // fetch and log detailed infos asynchronously
         servers.forEach(async (server) => {
@@ -440,11 +571,15 @@ const serverInfo = {
 };
 
 const debug = {
-  command: utils.addDevPrefix(`!totd debug`),
+  slashCommand: {
+    name: `debug`,
+    description: `Placeholder command for testing.`,
+    type: `CHAT_INPUT`,
+  },
   action: async (msg) => {
-    if (msg.author.tag === adminTag) {
+    if (utils.checkMessageAuthorForTag(msg, adminTag)) {
       try {
-        await msg.channel.send(`Debug me!`);
+        utils.sendMessage(msg.channel, `Debug me!`, msg);
       } catch (error) {
         discordAPI.sendErrorMessage(msg.channel);
         console.error(error);
@@ -453,28 +588,30 @@ const debug = {
   }
 };
 
-module.exports = [
-  help,
-  invite,
-  refresh,
-  refreshLeaderboard,
-  refreshRatings,
-  refreshBingo,
-  debug,
-  today,
-  leaderboard,
-  ratings,
-  rankings,
-  verdict,
-  enable,
-  disable,
-  setRole,
-  removeRole,
-  bingo,
-  lastBingo,
-  bingoVote,
-  bingoCount,
-  setAdminServer,
-  removeAdminServer,
-  serverInfo
-];
+module.exports = {
+  globalCommands: [
+    help,
+    invite,
+    today,
+    leaderboard,
+    ratings,
+    rankings,
+    verdict,
+    enable,
+    disable,
+    setRole,
+    removeRole,
+    bingo,
+    lastBingo,
+    bingoVote,
+  ],
+  adminCommands: [
+    refresh,
+    refreshLeaderboard,
+    refreshRatings,
+    refreshBingo,
+    refreshBingoCount,
+    debug,
+    serverInfo
+  ]
+};

--- a/src/discordAPI.js
+++ b/src/discordAPI.js
@@ -170,9 +170,9 @@ const sendTOTDMessage = async (client, channel, message, commandMessage) => {
     for (let i = 0; i < constants.ratingEmojis.length; i++) {
       emojis.push(utils.getEmojiMapping(constants.ratingEmojis[i]));
     }
-    emojis.forEach(async (emoji) => {
+    for (const emoji of emojis) {
       await discordMessage.react(emoji);
-    });
+    }
     return Promise.resolve();
   } catch (error) {
     console.log(`Couldn't send TOTD message to #${channel.name} in ${channel.guild.name}, throwing error`);

--- a/src/discordAPI.js
+++ b/src/discordAPI.js
@@ -5,6 +5,8 @@ const utils = require(`./utils`);
 const constants = require(`./constants`);
 const rating = require(`./rating`);
 
+const adminChannelID = process.env.ADMIN_CHANNEL_ID;
+
 const errorMessage = `Oops, something went wrong here - please talk to <@141627532335251456> and let him know that didn't work.`;
 
 const getTOTDMessage = async (forceRefresh) => {
@@ -159,10 +161,10 @@ const getBingoMessage = async (forceRefresh, lastWeek) => {
   }
 };
 
-const sendTOTDMessage = async (client, channel, message) => {
+const sendTOTDMessage = async (client, channel, message, commandMessage) => {
   try {
     console.log(`Sending current TOTD to #${channel.name} in ${channel.guild.name}`);
-    const discordMessage = await channel.send(message);
+    const discordMessage = await utils.sendMessage(channel, message, commandMessage);
     // add rating emojis
     const emojis = [];
     for (let i = 0; i < constants.ratingEmojis.length; i++) {
@@ -178,8 +180,8 @@ const sendTOTDMessage = async (client, channel, message) => {
   }
 };
 
-const sendTOTDLeaderboard = async (client, channel) => {
-  const discordMessage = await channel.send(`Fetching current leaderboard, give me a second... ${utils.getEmojiMapping(`Loading`)}`);
+const sendTOTDLeaderboard = async (client, channel, commandMessage) => {
+  const discordMessage = await utils.sendMessage(channel, `Fetching current leaderboard, give me a second... ${utils.getEmojiMapping(`Loading`)}`, commandMessage);
 
   const leaderboardMessage = await getTOTDLeaderboardMessage();
 
@@ -187,21 +189,21 @@ const sendTOTDLeaderboard = async (client, channel) => {
   discordMessage.edit(leaderboardMessage);
 };
 
-const sendTOTDRatings = async (client, channel, yesterday) => {
+const sendTOTDRatings = async (client, channel, yesterday, commandMessage) => {
   const ratingString = yesterday ? `yesterday's verdict` : `current rating`;
   console.log(`Sending ${ratingString} to #${channel.name} in ${channel.guild.name}`);
   const message = await getRatingMessage(yesterday);
-  await channel.send(message);
+  await utils.sendMessage(channel, message, commandMessage);
 };
 
-const sendBingoBoard = async (channel, lastWeek) => {
+const sendBingoBoard = async (channel, lastWeek, commandMessage) => {
   const bingoString = lastWeek ? `last week's` : `current`;
   console.log(`Sending ${bingoString} bingo board to #${channel.name} in ${channel.guild.name}`);
   const message = await getBingoMessage(false, lastWeek);
-  await channel.send(message);
+  await utils.sendMessage(channel, message, commandMessage);
 };
 
-const sendBingoVote = async (channel, bingoID) => {
+const sendBingoVote = async (channel, bingoID, commandMessage) => {
   const redisClient = await redisAPI.login();
   let board = await redisAPI.getBingoBoard(redisClient);
 
@@ -209,23 +211,25 @@ const sendBingoVote = async (channel, bingoID) => {
   board.splice(12, 0, {text: `Free space`, checked: false});
 
   if (bingoID < 1 || bingoID > 25) {
-    return await channel.send(`Hmm, that's not on the board. I only understand numbers from 1 to 25 I'm afraid.`);
+    return await utils.sendMessage(channel, `Hmm, that's not on the board. I only understand numbers from 1 to 25 I'm afraid.`, commandMessage);
   } else if (bingoID === 13) {
-    return await channel.send(`You want to vote on the free space? Are you okay?`);
+    return await utils.sendMessage(channel, `You want to vote on the free space? Are you okay?`, commandMessage);
   }
 
   const field = board[bingoID - 1];
   if (field.checked) {
-    return await channel.send(`Looks like that field is already checked off for this week.`);
+    return await utils.sendMessage(channel, `Looks like that field is already checked off for this week.`, commandMessage);
   } else if (field.voteActive) {
-    return await channel.send(`There's already a vote going on for that field, check again tomorrow.`);
+    return await utils.sendMessage(channel, `There's already a vote going on for that field, check again tomorrow.`, commandMessage);
   }
 
   const textWithoutBreaks = field.text.replace(/\n/g, ` `);
-  const voteMessage = await channel.send(
+  const voteMessage = await utils.sendMessage(
+    channel,
     `Bingo vote started: **${textWithoutBreaks}**\n` +
-    `Does that sound like today's track?\n` +
-    `Vote using the reactions below - I'll close the vote when the next TOTD comes out.`
+      `Does that sound like today's track?\n` +
+      `Vote using the reactions below - I'll close the vote when the next TOTD comes out.`,
+    commandMessage
   );
 
   const voteYes = utils.getEmojiMapping(`VoteYes`);
@@ -358,13 +362,10 @@ const archiveRatings = async (client, oldTOTD) => {
       await redisAPI.saveRatingRankings(redisClient, constants.ratingRankingType.monthly, {top: [], bottom: []});
     }
 
-    // send ratings to admin server if it's been configured
-    const adminConfig = await redisAPI.getAdminServer(redisClient);
-    if (adminConfig?.channelID) {
-      console.log(`Sending verdict to admin server...`);
-      const adminChannel = await client.channels.fetch(adminConfig.channelID);
-      adminChannel.send(await getRatingMessage(true));
-    }
+    // send ratings to admin server
+    console.log(`Sending verdict to admin server...`);
+    const adminChannel = await client.channels.fetch(adminChannelID);
+    utils.sendMessage(adminChannel, await getRatingMessage(true));
   }
   await redisAPI.clearTOTDRatings(redisClient);
 
@@ -428,7 +429,7 @@ const sendCOTDPings = async (client, region) => {
       try {
         const channel = await client.channels.fetch(config.channelID);
         console.log(`Pinging ${config[roleProp]} in #${channel.name} (${channel.guild.name})`);
-        channel.send(`${config[roleProp]} The Cup of the Day is about to begin! ${utils.getEmojiMapping(`COTDPing`)} Ten minutes to go!`);
+        utils.sendMessage(channel, `${config[roleProp]} The Cup of the Day is about to begin! ${utils.getEmojiMapping(`COTDPing`)} Ten minutes to go!`);
       } catch (error) {
         if (error.message === `Missing Access`) {
           console.log(`Can't access server, bot was probably kicked.`);
@@ -478,7 +479,7 @@ const updateTOTDReactionCount = async (reaction, add, user) => {
 };
 
 const sendErrorMessage = (channel) => {
-  channel.send(errorMessage);
+  utils.sendMessage(channel, errorMessage);
 };
 
 module.exports = {

--- a/src/discordAPI.js
+++ b/src/discordAPI.js
@@ -453,10 +453,12 @@ const updateTOTDReactionCount = async (reaction, add, user) => {
   );
   if (currentMapUid === reactionMapUid) {
     const ratingEmojis = constants.ratingEmojis;
+    let ratingEmojiFound = false;
     for (let i = 0; i < ratingEmojis.length; i++) {
       const ratingIdentifier = utils.getEmojiMapping(ratingEmojis[i]);
 
       if (ratingIdentifier.includes(reaction.emoji.identifier)) {
+        ratingEmojiFound = true;
         // check if this is a valid rating (i.e. not a duplicate from this user)
         const valid = await redisAPI.updateIndividualRatings(redisClient, reaction.emoji.name, add, user.id);
         const emojiInfo = `[${user.tag} ${add ? `added` : `removed`} ${reaction.emoji.name}]`;
@@ -467,9 +469,11 @@ const updateTOTDReactionCount = async (reaction, add, user) => {
         } else {
           console.log(`Rating reaction in #${reaction.message.channel.name} (${reaction.message.channel.guild.name}) ${emojiInfo} [duplicate]`);
         }
-
         break;
       }
+    }
+    if (!ratingEmojiFound) {
+      await reaction.remove();
     }
     redisAPI.logout(redisClient);
   } else {

--- a/src/format.js
+++ b/src/format.js
@@ -304,7 +304,7 @@ const resolveRatingToEmoji = (rating) => {
 const formatRankingMessage = (rankings, timeframe) => {
   // if top and bottom are empty, return a basic placeholder
   if (rankings?.top.length === 0 || rankings?.bottom.length === 0) {
-    return `It seems I don't have any data for the timeframe "${timeframe.label}" yet, sorry!`;
+    return `It seems I don't have any data for that timeframe yet, sorry!`;
   }
 
   const formatRankingRows = (rankingItems) => {
@@ -314,7 +314,7 @@ const formatRankingMessage = (rankings, timeframe) => {
       const rating = `${resolveRatingToEmoji(rankingItem.averageRating)} (${rankingItem.averageRating})`;
       let date = ``;
       if (rankingItem.date) {
-        if (timeframe.value === constants.ratingRankingType.allTime || timeframe.value === constants.ratingRankingType.lastYearly) {
+        if (timeframe === constants.ratingRankingType.allTime || timeframe === constants.ratingRankingType.lastYearly) {
           date = `${rankingItem.date} `;
         } else {
           date += `${rankingItem.date.slice(0, -5)} `;
@@ -332,13 +332,13 @@ const formatRankingMessage = (rankings, timeframe) => {
   };
 
   let titleTimeframe = `this month`;
-  if (timeframe.value === constants.ratingRankingType.lastMonthly) {
+  if (timeframe === constants.ratingRankingType.lastMonthly) {
     titleTimeframe = `last month`;
-  } else if (timeframe.value === constants.ratingRankingType.yearly) {
+  } else if (timeframe === constants.ratingRankingType.yearly) {
     titleTimeframe = `this year`;
-  } else if (timeframe.value === constants.ratingRankingType.lastYearly) {
+  } else if (timeframe === constants.ratingRankingType.lastYearly) {
     titleTimeframe = `last year`;
-  } else if (timeframe.value === constants.ratingRankingType.allTime) {
+  } else if (timeframe === constants.ratingRankingType.allTime) {
     titleTimeframe = `all time`;
   }
 
@@ -367,18 +367,18 @@ const formatRankingMessage = (rankings, timeframe) => {
   }
 
   // add disclaimer to description that month isn't over yet
-  if (timeframe.value === constants.ratingRankingType.monthly) {
+  if (timeframe === constants.ratingRankingType.monthly) {
     const description1 = `The month isn't over yet, so these aren't final -`;
-    const description2 = `check \`${utils.addDevPrefix(`!totd rankings last month`)}\` when it's over to see the final rankings!`;
+    const description2 = `check \`${utils.addDevPrefix(`/rankings last month`)}\` when it's over to see the final rankings!`;
     embed.description = `${description1} ${description2}`;
-  } else if (timeframe.value === constants.ratingRankingType.yearly) {
+  } else if (timeframe === constants.ratingRankingType.yearly) {
     const description1 = `The year isn't over yet, so these aren't final -`;
-    const description2 = `check \`${utils.addDevPrefix(`!totd rankings last year`)}\` when it's over to see the final rankings!`;
+    const description2 = `check \`${utils.addDevPrefix(`/rankings last year`)}\` when it's over to see the final rankings!`;
     embed.description = `${description1} ${description2}`;
   }
 
   // for allTime add disclaimer to footer
-  if (timeframe.value === constants.ratingRankingType.allTime) {
+  if (timeframe === constants.ratingRankingType.allTime) {
     const footer1 = `This ranking only displays data starting from July 2021 - earlier bot ratings were not representative enough.`;
     const footer2 = `So don't take this too seriously if it's missing your favorite track!`;
     embed.footer = {
@@ -519,8 +519,8 @@ const formatBingoBoard = async (fields, lastWeek) => {
 
   const embedDescription = 
     lastWeek
-      ? `This board is closed - use \`${utils.addDevPrefix(`!totd bingo`)}\` to see the current one.`
-      : `If you think we should cross one of these off, you can start a vote using \`${utils.addDevPrefix(`!totd vote [1-25]`)}\`.`;
+      ? `This board is closed - use \`${utils.addDevPrefix(`/bingo`)}\` to see the current one.`
+      : `If you think we should cross one of these off, you can start a vote using \`${utils.addDevPrefix(`/bingovote [1-25]`)}\`.`;
 
   const embed = {
     title: `Here's the TOTD bingo board for week ${weekNumber}!`,
@@ -577,7 +577,7 @@ const formatHelpMessage = (commands, adminCommands) => {
           `I've been developed by tooInfinite#5113 (<@141627532335251456>) - feel free to talk to him if you've got any feedback or ran into any issues with me. \
           My code can be found [here](https://github.com/davidbmaier/totd-bot). \n\
           If you want to, you can [help pay for my hosting](https://github.com/sponsors/davidbmaier). Never required, always appreciated! \n\
-          To invite me to your own server, click [here](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=bot).`
+          To invite me to your own server, click [here](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=applications.commands%20bot).`
       }
     ]
   };
@@ -592,16 +592,13 @@ const formatHelpMessage = (commands, adminCommands) => {
   return {embeds: [embed]};
 };
 
-const formatInviteMessage = () => {
+const formatInviteMessage = (title, message) => {
+  const inviteLink = `For the invite link, click [here](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=applications.commands%20bot)!`;
   return {
     embeds: [{
       type: `rich`,
-      fields: [
-        {
-          name: `Want to invite me to your own server?`,
-          value: `Click [here](https://discord.com/api/oauth2/authorize?client_id=807920588738920468&permissions=388160&scope=bot)!`
-        }
-      ]
+      title: title || `Want to invite me to your own server?`,
+      description: `${message || ``}\n${inviteLink}`,
     }]
   };
 };

--- a/src/redisApi.js
+++ b/src/redisApi.js
@@ -26,41 +26,6 @@ const logout = (redisClient) => {
   });
 };
 
-const getAdminServer = (redisClient) => {
-  return new Promise((resolve, reject) => {
-    redisClient.get(`adminServer`, (err, adminConfig) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(JSON.parse(adminConfig) || {});
-      }
-    });
-  });
-};
-
-const setAdminServer = (redisClient, adminServerID, adminChannelID) => {
-  return new Promise((resolve, reject) => {
-    if (adminServerID !== null) {
-      redisClient.set(`adminServer`, JSON.stringify({serverID: adminServerID, channelID: adminChannelID}), (err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    } else {
-      // setAdminServer to null = delete adminServer config
-      redisClient.del(`adminServer`, (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
-    }
-  });
-};
-
 const getConfigs = (redisClient) => {
   return new Promise((resolve, reject) => {
     redisClient.get(`serverConfigs`, (err, configs) => {
@@ -522,8 +487,6 @@ const saveBingoBoard = async (redisClient, board, lastWeek) => {
 module.exports = {
   login,
   logout,
-  getAdminServer,
-  setAdminServer,
   addConfig,
   removeConfig,
   addRole,

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,11 +60,36 @@ const formatDay = (day) => {
   }
 };
 
+const sendMessage = async (channel, message, commandMessage) => {
+  if (commandMessage) {
+    let messageObject = {};
+    // add fetchReply depending on the message format
+    if (typeof message === `string`) {
+      messageObject = {
+        content: message,
+        fetchReply: true
+      };
+    } else {
+      messageObject = {...message, fetchReply: true};
+    }
+    return await commandMessage.reply(messageObject);
+  } else {
+    return await channel.send(message);
+  }
+};
+
+const checkMessageAuthorForTag = (msg, tag) => {
+  const author = msg.author || msg.user;
+  return author.tag === tag;
+};
+
 module.exports = {
   addDevPrefix,
   convertToUNIXSeconds,
   getMinutesAgo,
   getEmojiMapping,
   removeNameFormatting,
-  formatDay
+  formatDay,
+  sendMessage,
+  checkMessageAuthorForTag
 };


### PR DESCRIPTION
Big restructuring to be able to remove the `message content` intent soon so the bot can be verified.

- Added global admin channel to configuration (instead of setting it at runtime).
- Reworked command structure to remove in-message commands and switch to slash commands completely.
- Rewrote readme and help command.
- Added logic to properly register slash commands on startup.
- Blocked off previous in-message commands with an explanation.
- Changed invite links everywhere for slash command permissions.
- Simplified and extracted some internal Discord API-related logic for compatibility and ease of use.
- Added temporary command to notify server owners through DMs if the bot doesn't have slash command permissions on their server.
- Updated version to `1.0` - this contains enough breaking changes, and the bot will likely be verified soon which would justify a first real major version.

This also changes how the bot is run in development mode - instead of using the same application and a different prefix, it's now encouraged to use a separate application.